### PR TITLE
Use file-based configuration for run script

### DIFF
--- a/config/run.json
+++ b/config/run.json
@@ -1,0 +1,17 @@
+{
+  "path": "path/to/train.tsv",
+  "parameter_file": "paramfiles/rsc15_xe_shared_100_best.py",
+  "test": ["path/to/test.tsv"],
+  "measure": [20],
+  "eval_type": "standard",
+  "device": "cuda:0",
+  "sample_store_size": 10000000,
+  "gru4rec_model": "gru4rec_pytorch",
+  "item_key": "ItemId",
+  "session_key": "SessionId",
+  "time_key": "Time",
+  "primary_metric": "recall",
+  "log_primary_metric": false,
+  "load_model": false,
+  "save_model": null
+}

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,36 @@
+import json
+import os
+from typing import Any, Dict
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    """Load a JSON or YAML configuration file.
+
+    Args:
+        path: Location of the configuration file.
+
+    Returns:
+        A dictionary with the loaded configuration.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file extension is unsupported or YAML support is
+            requested but unavailable.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    ext = os.path.splitext(path)[1].lower()
+    with open(path, "r") as fh:
+        if ext == ".json":
+            return json.load(fh)
+        if ext in {".yaml", ".yml"}:
+            if yaml is None:
+                raise ValueError("PyYAML is required to load YAML files")
+            return yaml.safe_load(fh)
+    raise ValueError(f"Unsupported config extension: {ext}")

--- a/run.py
+++ b/run.py
@@ -1,32 +1,41 @@
-import argparse
 import os
-import shutil
+from types import SimpleNamespace
 
-class MyHelpFormatter(argparse.HelpFormatter):
-    def __init__(self, *args, **kwargs):
-        super(MyHelpFormatter, self).__init__(*args, **kwargs)
-        self._width = shutil.get_terminal_size().columns
+import config_loader
 
-parser = argparse.ArgumentParser(formatter_class=MyHelpFormatter, description='Train or load a GRU4Rec model & measure recall and MRR on the specified test set(s).')
-parser.add_argument('path', metavar='PATH', type=str, help='Path to the training data (TAB separated file (.tsv or .txt) or pickled pandas.DataFrame object (.pickle)) (if the --load_model parameter is NOT provided) or to the serialized model (if the --load_model parameter is provided).')
-parser.add_argument('-ps', '--parameter_string', metavar='PARAM_STRING', type=str, help='Training parameters provided as a single parameter string. The format of the string is `param_name1=param_value1,param_name2=param_value2...`, e.g.: `loss=bpr-max,layers=100,constrained_embedding=True`. Boolean training parameters should be either True or False; parameters that can take a list should use / as the separator (e.g. layers=200/200). Mutually exclusive with the -pf (--parameter_file) and the -l (--load_model) arguments and one of the three must be provided.')
-parser.add_argument('-pf', '--parameter_file', metavar='PARAM_PATH', type=str, help='Alternatively, training parameters can be set using a config file specified in this argument. The config file must contain a single OrderedDict named `gru4rec_params`. The parameters must have the appropriate type (e.g. layers = [100]). Mutually exclusive with the -ps (--parameter_string) and the -l (--load_model) arguments and one of the three must be provided.')
-parser.add_argument('-l', '--load_model', action='store_true', help='Load an already trained model instead of training a model. Mutually exclusive with the -ps (--parameter_string) and the -pf (--parameter_file) arguments and one of the three must be provided.')
-parser.add_argument('-s', '--save_model', metavar='MODEL_PATH', type=str, help='Save the trained model to the MODEL_PATH. (Default: don\'t save model)')
-parser.add_argument('-t', '--test', metavar='TEST_PATH', type=str, nargs='+', help='Path to the test data set(s) located at TEST_PATH. Multiple test sets can be provided (separate with spaces). (Default: don\'t evaluate the model)')
-parser.add_argument('-m', '--measure', metavar='AT', type=int, nargs='+', default=[20], help='Measure recall & MRR at the defined recommendation list length(s). Multiple values can be provided. (Default: 20)')
-parser.add_argument('-e', '--eval_type', metavar='EVAL_TYPE', choices=['standard', 'conservative', 'median'], default='standard', help='Sets how to handle if multiple items in the ranked list have the same prediction score (which is usually due to saturation or an error). See the documentation of batch_eval() in evaluation.py for further details. (Default: standard)')
-parser.add_argument('-ss', '--sample_store_size', metavar='SS', type=int, default=10000000, help='GRU4Rec uses a buffer for negative samples during training to maximize GPU utilization. This parameter sets the buffer length. Lower values require more frequent recomputation, higher values use more (GPU) memory. Unless you know what you are doing, you shouldn\'t mess with this parameter. (Default: 10000000)')
-parser.add_argument('-g', '--gru4rec_model', metavar='GRFILE', type=str, default='gru4rec_pytorch', help='Name of the file containing the GRU4Rec class. Can be used to select different varaiants. (Default: gru4rec_pytorch)')
-parser.add_argument('-d', '--device', metavar='D', type=str, default='cuda:0', help='Device used for computations (default: cuda:0).')
-parser.add_argument('-ik', '--item_key', metavar='IK', type=str, default='ItemId', help='Column name corresponding to the item IDs (detault: ItemId).')
-parser.add_argument('-sk', '--session_key', metavar='SK', type=str, default='SessionId', help='Column name corresponding to the session IDs (default: SessionId).')
-parser.add_argument('-tk', '--time_key', metavar='TK', type=str, default='Time', help='Column name corresponding to the timestamp (default: Time).')
-parser.add_argument('-pm', '--primary_metric', metavar='METRIC', choices=['recall', 'mrr'], default='recall', help='Set primary metric, recall or mrr (e.g. for paropt). (Default: recall)')
-parser.add_argument('-lpm', '--log_primary_metric', action='store_true', help='If provided, evaluation will log the value of the primary metric at the end of the run. Only works with one test file and list length.')
-args = parser.parse_args()
+CONFIG_ENV_VAR = "GRU4REC_RUN_CONFIG"
+DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config", "run.json")
+config_path = os.environ.get(CONFIG_ENV_VAR, DEFAULT_CONFIG_PATH)
+config = config_loader.load_config(config_path)
 
-import os.path
+defaults = {
+    "measure": [20],
+    "eval_type": "standard",
+    "sample_store_size": 10000000,
+    "gru4rec_model": "gru4rec_pytorch",
+    "device": "cuda:0",
+    "item_key": "ItemId",
+    "session_key": "SessionId",
+    "time_key": "Time",
+    "primary_metric": "recall",
+    "log_primary_metric": False,
+    "save_model": None,
+    "load_model": False,
+    "test": None,
+    "parameter_string": None,
+    "parameter_file": None,
+}
+
+for key, val in defaults.items():
+    config.setdefault(key, val)
+
+if config.get("test") is not None and not isinstance(config["test"], list):
+    config["test"] = [config["test"]]
+if not isinstance(config.get("measure"), list):
+    config["measure"] = [config.get("measure")]
+
+args = SimpleNamespace(**config)
+
 orig_cwd = os.getcwd()
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 import numpy as np


### PR DESCRIPTION
## Summary
- add `config_loader` module to read JSON or YAML configs
- replace argparse in `run.py` with config file loading and defaults
- add sample `config/run.json` and support `GRU4REC_RUN_CONFIG` env override

## Testing
- `python -m py_compile config_loader.py run.py`
- `GRU4REC_RUN_CONFIG=config/run.json python run.py` *(fails: FileNotFoundError: path/to/train.tsv)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f7ad6260832b8c756068f68178de