### PR TITLE
Load paropt settings from config file

### DIFF
--- a/config/paropt.json
+++ b/config/paropt.json
@@ -1,0 +1,16 @@
+{
+  "path": "path/to/train.tsv",
+  "test": "path/to/test.tsv",
+  "gru4rec_model": "gru4rec_pytorch",
+  "fixed_parameters": "loss=bpr-max",
+  "optuna_parameter_file": "paramspaces/gru4rec_xe_standard_parspace.json",
+  "measure": 20,
+  "ntrials": 50,
+  "final_measure": [20],
+  "primary_metric": "recall",
+  "eval_type": "standard",
+  "device": "cuda:0",
+  "item_key": "ItemId",
+  "session_key": "SessionId",
+  "time_key": "Time"
+}

--- a/config_loader.py
+++ b/config_loader.py
@@ -34,3 +34,40 @@ def load_config(path: str) -> Dict[str, Any]:
                 raise ValueError("PyYAML is required to load YAML files")
             return yaml.safe_load(fh)
     raise ValueError(f"Unsupported config extension: {ext}")
+
+
+def load_paropt_config(path: str) -> Dict[str, Any]:
+    """Load configuration for the paropt utility.
+
+    The configuration is read from ``path`` and supplemented with default
+    values for optional fields.
+
+    Args:
+        path: Location of the configuration file.
+
+    Returns:
+        A dictionary containing the paropt configuration.
+    """
+    config = load_config(path)
+
+    defaults = {
+        "gru4rec_model": "gru4rec_pytorch",
+        "fixed_parameters": "",
+        "measure": 20,
+        "ntrials": 50,
+        "final_measure": [20],
+        "primary_metric": "recall",
+        "eval_type": "standard",
+        "device": "cuda:0",
+        "item_key": "ItemId",
+        "session_key": "SessionId",
+        "time_key": "Time",
+    }
+
+    for key, val in defaults.items():
+        config.setdefault(key, val)
+
+    if not isinstance(config.get("final_measure"), list):
+        config["final_measure"] = [config["final_measure"]]
+
+    return config

--- a/paropt.py
+++ b/paropt.py
@@ -1,50 +1,54 @@
-import argparse
 import os
-import optuna
 import json
-
-class MyHelpFormatter(argparse.HelpFormatter):
-    def __init__(self, *args, **kwargs):
-        super(MyHelpFormatter, self).__init__(*args, **kwargs)
-        try:
-            columns = int(os.popen('stty size', 'r').read().split()[1])
-        except:
-            columns = None
-        if columns is not None:
-            self._width = columns
-
-parser = argparse.ArgumentParser(formatter_class=MyHelpFormatter, description='Train or load a GRU4Rec model & measure recall and MRR on the specified test set(s).')
-parser.add_argument('path', metavar='PATH', type=str, help='Path to the training data (TAB separated file (.tsv or .txt) or pickled pandas.DataFrame object (.pickle)) (if the --load_model parameter is NOT provided) or to the serialized model (if the --load_model parameter is provided).')
-parser.add_argument('test', metavar='TEST_PATH', type=str, help='Path to the test data set(s) located at TEST_PATH.')
-parser.add_argument('-g', '--gru4rec_model', metavar='GRFILE', type=str, default='gru4rec_pytorch', help='Name of the file containing the GRU4Rec class. Can be sued to select different varaiants. (Default: gru4rec_pytorch)')
-parser.add_argument('-fp', '--fixed_parameters', metavar='PARAM_STRING', type=str, help='Fixed training parameters provided as a single parameter string. The format of the string is `param_name1=param_value1,param_name2=param_value2...`, e.g.: `loss=bpr-max,layers=100,constrained_embedding=True`. Boolean training parameters should be either True or False; parameters that can take a list should use / as the separator (e.g. layers=200/200). Mutually exclusive with the -pf (--parameter_file) and the -l (--load_model) arguments and one of the three must be provided.')
-parser.add_argument('-opf', '--optuna_parameter_file', metavar='PATH', type=str, help='File describing the parameter space for optuna.')
-parser.add_argument('-m', '--measure', metavar='AT', type=int, nargs='?', default=20, help='Measure recall & MRR at the defined recommendation list length. A single values can be provided. (Default: 20)')
-parser.add_argument('-nt', '--ntrials', metavar='NT', type=int, nargs='?', default=50, help='Number of optimization trials to perform (Default: 50)')
-parser.add_argument('-fm', '--final_measure', metavar='AT', type=int, nargs='*', default=[20], help='Measure recall & MRR at the defined recommendation list length(s) after the optimization is finished. Multiple values can be provided. (Default: 20)')
-parser.add_argument('-pm', '--primary_metric', metavar='METRIC', choices=['recall', 'mrr'], default='recall', help='Set primary metric, recall or mrr (e.g. for paropt). (Default: recall)')
-parser.add_argument('-e', '--eval_type', metavar='EVAL_TYPE', choices=['standard', 'conservative', 'median', 'tiebreaking'], default='standard', help='Sets how to handle if multiple items in the ranked list have the same prediction score (which is usually due to saturation or an error). See the documentation of evaluate_gpu() in evaluation.py for further details. (Default: standard)')
-parser.add_argument('-d', '--device', metavar='D', type=str, default='cuda:0', help='Device used for computations (default: cuda:0).')
-parser.add_argument('-ik', '--item_key', metavar='IK', type=str, default='ItemId', help='Column name corresponding to the item IDs (detault: ItemId).')
-parser.add_argument('-sk', '--session_key', metavar='SK', type=str, default='SessionId', help='Column name corresponding to the session IDs (default: SessionId).')
-parser.add_argument('-tk', '--time_key', metavar='TK', type=str, default='Time', help='Column name corresponding to the timestamp (default: Time).')
-
-args = parser.parse_args()
-
-import pexpect
-import numpy as np
-from collections import OrderedDict
-import importlib
+import optuna
 import re
+import tempfile
+from types import SimpleNamespace
 
-def generate_command(optimized_param_str):
-    command = 'python run.py "{}" -t "{}" -g {} -ps {},{} -m {} -pm {} -lpm -e {} -d {} -ik {} -sk {} -tk {}'.format(args.path, args.test, args.gru4rec_model, args.fixed_parameters, optimized_param_str, args.measure, args.primary_metric, args.eval_type, args.device, args.item_key, args.session_key, args.time_key)
-    return command
+import config_loader
+import pexpect
+
+CONFIG_ENV_VAR = "GRU4REC_PAROPT_CONFIG"
+DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "config", "paropt.json"
+)
+config_path = os.environ.get(CONFIG_ENV_VAR, DEFAULT_CONFIG_PATH)
+config = SimpleNamespace(**config_loader.load_paropt_config(config_path))
+
+
+def generate_command(optimized_param_str, measure, log_primary_metric=True):
+    """Create command to invoke run.py with a temporary config file."""
+    param_parts = [config.fixed_parameters] if config.fixed_parameters else []
+    if optimized_param_str:
+        param_parts.append(optimized_param_str)
+
+    run_config = {
+        "path": config.path,
+        "test": config.test if isinstance(config.test, list) else [config.test],
+        "gru4rec_model": config.gru4rec_model,
+        "parameter_string": ",".join(param_parts),
+        "measure": measure,
+        "eval_type": config.eval_type,
+        "device": config.device,
+        "item_key": config.item_key,
+        "session_key": config.session_key,
+        "time_key": config.time_key,
+        "primary_metric": config.primary_metric,
+        "log_primary_metric": log_primary_metric,
+    }
+
+    tmp = tempfile.NamedTemporaryFile("w", delete=False, suffix=".json")
+    json.dump(run_config, tmp)
+    tmp.close()
+    command = f'GRU4REC_RUN_CONFIG="{tmp.name}" python run.py'
+    return command, tmp.name
+
 
 def run_once(optimized_param_str):
-    command = generate_command(optimized_param_str)
+    command, cfg_path = generate_command(optimized_param_str, config.measure, True)
     cmd = pexpect.spawnu(command, timeout=None, maxread=1)
     line = cmd.readline()
+    val = None
     while line:
         line = line.strip()
         print(line)
@@ -53,67 +57,93 @@ def run_once(optimized_param_str):
             val = float(t)
             break
         line = cmd.readline()
+    cmd.wait()
+    os.remove(cfg_path)
     return val
+
 
 class Parameter:
     def __init__(self, name, dtype, values, step=None, log=False):
         assert dtype in ['int', 'float', 'categorical']
-        assert type(values)==list
-        assert len(values)==2 or dtype=='categorical'
+        assert type(values) == list
+        assert len(values) == 2 or dtype == 'categorical'
         self.name = name
         self.dtype = dtype
         self.values = values
         self.step = step
-        if self.step is None and self.dtype=='int':
+        if self.step is None and self.dtype == 'int':
             self.step = 1
         self.log = log
+
     @classmethod
     def fromjson(cls, json_string):
         obj = json.loads(json_string)
-        return Parameter(obj['name'], obj['dtype'], obj['values'], obj['step'] if 'step' in obj else None, obj['log'] if 'log' in obj else False)
+        return Parameter(
+            obj['name'],
+            obj['dtype'],
+            obj['values'],
+            obj['step'] if 'step' in obj else None,
+            obj['log'] if 'log' in obj else False,
+        )
+
     def __call__(self, trial):
         if self.dtype == 'int':
-            return trial.suggest_int(self.name, int(self.values[0]), int(self.values[1]), step=self.step, log=self.log)
+            return trial.suggest_int(
+                self.name, int(self.values[0]), int(self.values[1]), step=self.step, log=self.log
+            )
         if self.dtype == 'float':
-            return trial.suggest_float(self.name, float(self.values[0]), float(self.values[1]), step=self.step, log=self.log)
+            return trial.suggest_float(
+                self.name, float(self.values[0]), float(self.values[1]), step=self.step, log=self.log
+            )
         if self.dtype == 'categorical':
             return trial.suggest_categorical(self.name, self.values)
+
     def __str__(self):
         desc = 'PARAMETER {} \t type={}'.format(self.name, self.dtype)
         if self.dtype == 'int' or self.dtype == 'float':
-            desc += ' \t range=[{}..{}] (step={}) \t {} scale'.format(self.values[0], self.values[1], self.step if self.step is not None else 'N/A', 'UNIFORM' if not self.log else 'LOG')
+            desc += ' \t range=[{}..{}] (step={}) \t {} scale'.format(
+                self.values[0],
+                self.values[1],
+                self.step if self.step is not None else 'N/A',
+                'UNIFORM' if not self.log else 'LOG',
+            )
         if self.dtype == 'categorical':
             desc += ' \t options: [{}]'.format(','.join([str(x) for x in self.values]))
         return desc
-        
+
+
 def objective(trial, par_space):
     optimized_param_str = []
     for par in par_space:
         val = par(trial)
-        optimized_param_str.append('{}={}'.format(par.name,val))
+        optimized_param_str.append('{}={}'.format(par.name, val))
     optimized_param_str = ','.join(optimized_param_str)
     val = run_once(optimized_param_str)
     return val
 
+
 par_space = []
-with open(args.optuna_parameter_file, 'rt') as f:
-    print('-'*80)
+with open(config.optuna_parameter_file, 'rt') as f:
+    print('-' * 80)
     print('PARAMETER SPACE')
     for line in f:
         par = Parameter.fromjson(line)
         print('\t' + str(par))
         par_space.append(par)
-    print('-'*80)
+    print('-' * 80)
 
 study = optuna.create_study(direction='maximize')
-study.optimize(lambda trial: objective(trial, par_space), n_trials=args.ntrials)
+study.optimize(lambda trial: objective(trial, par_space), n_trials=config.ntrials)
 
-print('Running final eval @{}:'.format(args.final_measure))
-optimized_param_str = ','.join(['{}={}'.format(k,v) for k,v in study.best_params.items()])
-command = 'python run.py "{}" -t "{}" -g {} -ps {},{} -m {} -e {} -d {} -ik {} -sk {} -tk {}'.format(args.path, args.test, args.gru4rec_model, args.fixed_parameters, optimized_param_str, ' '.join([str(x) for x in args.final_measure]), args.eval_type, args.device, args.item_key, args.session_key, args.time_key)
+print('Running final eval @{}:'.format(config.final_measure))
+optimized_param_str = ','.join(['{}={}'.format(k, v) for k, v in study.best_params.items()])
+command, cfg_path = generate_command(optimized_param_str, config.final_measure, False)
 cmd = pexpect.spawnu(command, timeout=None, maxread=1)
 line = cmd.readline()
 while line:
     line = line.strip()
     print(line)
     line = cmd.readline()
+cmd.wait()
+os.remove(cfg_path)
+


### PR DESCRIPTION
## Summary
- Add `load_paropt_config` to `config_loader` and default values
- Replace `paropt` CLI with config-driven setup and dynamic run config generation
- Provide default `config/paropt.json`

## Testing
- `python -m py_compile config_loader.py paropt.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa31b8d0832b8be7aa33e0ed3bb0