### PR TITLE
Add YAML configuration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,40 @@ from gru4rec import train_valid_test_split
 train, valid, test = train_valid_test_split(df)
 ```
 
+## Configuration
+
+Model and data-split parameters can be stored in a YAML configuration file.
+An example is provided in `config/example.yaml`:
+
+```yaml
+model:
+  layers: [10]
+  n_epochs: 1
+  batch_size: 2
+  learning_rate: 0.05
+
+data_split:
+  valid_fraction: 0.1
+  test_fraction: 0.1
+```
+
+Adjust the values to match your dataset and desired training setup. Load the
+configuration and use it to initialise the split and model:
+
+```python
+import yaml
+from gru4rec import GRU4Rec, train_valid_test_split
+
+with open("config/example.yaml") as f:
+    cfg = yaml.safe_load(f)
+
+train, valid, test = train_valid_test_split(df, **cfg["data_split"])
+gru = GRU4Rec(**cfg["model"])
+gru.fit(train)
+```
+
+The notebook `example.ipynb` demonstrates this workflow end-to-end.
+
 ## Training
 
 ```python

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,0 +1,10 @@
+model:
+  layers: [10]
+  n_epochs: 1
+  batch_size: 2
+  learning_rate: 0.05
+  device: cpu
+
+data_split:
+  valid_fraction: 0.1
+  test_fraction: 0.1

--- a/example.ipynb
+++ b/example.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["# GRU4Rec Usage Example"]
+   "source": [
+    "# GRU4Rec Usage Example"
+   ]
   },
   {
    "cell_type": "code",
@@ -12,8 +14,19 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "import yaml\n",
     "from gru4rec import GRU4Rec, train_valid_test_split\n",
     "from gru4rec.evaluation import batch_eval\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"config/example.yaml\") as f:\n",
+    "    config = yaml.safe_load(f)\n"
    ]
   },
   {
@@ -35,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train, valid, test = train_valid_test_split(data)\n"
+    "train, valid, test = train_valid_test_split(data, **config['data_split'])\n"
    ]
   },
   {
@@ -44,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gru = GRU4Rec(layers=[10], n_epochs=1, batch_size=2)\n",
+    "gru = GRU4Rec(**config['model'])\n",
     "gru.fit(train)\n"
    ]
   },


### PR DESCRIPTION
## Summary
- Provide `config/example.yaml` with model hyperparameters and data-split fractions
- Load YAML config in `example.ipynb` to drive dataset splitting and GRU4Rec setup
- Document configuration workflow in `README.md`

## Testing
- `python - <<'PY' ... PY` *(fails: Could not set tensor of type double to a tensor of type float)*

------
https://chatgpt.com/codex/tasks/task_e_68a86cf985a4832bb5ae9ff7fdfe7249