### PR TITLE
Expand configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,34 +26,68 @@ train, valid, test = train_valid_test_split(df)
 
 ## Configuration
 
-Model and data-split parameters can be stored in a YAML configuration file.
-An example is provided in `config/example.yaml`:
+Model, data-loading, training and evaluation parameters can be stored in a YAML
+configuration file. An extended example is provided in
+`config/example.yaml`:
 
 ```yaml
 model:
   layers: [10]
-  n_epochs: 1
+  loss: cross-entropy
   batch_size: 2
+  dropout_p_embed: 0.0
+  dropout_p_hidden: 0.0
   learning_rate: 0.05
+  momentum: 0.0
+  sample_alpha: 0.5
+  n_sample: 2048
+  embedding: 0
+  constrained_embedding: true
+  n_epochs: 1
+  bpreg: 1.0
+  elu_param: 0.5
+  logq: 0.0
+  device: cpu
+
+data:
+  session_key: SessionId
+  item_key: ItemId
+  time_key: Time
 
 data_split:
   valid_fraction: 0.1
   test_fraction: 0.1
+
+training:
+  sample_cache_max_size: 10000000
+  compatibility_mode: true
+
+evaluation:
+  cutoff: [20]
+  batch_size: 512
+  mode: conservative
+
+paths:
+  model_save: model.pth
+  model_load: model.pth
 ```
 
-Adjust the values to match your dataset and desired training setup. Load the
-configuration and use it to initialise the split and model:
+Use the helper functions to load the configuration, split the data and build
+the model:
 
 ```python
-import yaml
-from gru4rec import GRU4Rec, train_valid_test_split
+from gru4rec import (
+    load_config,
+    build_model,
+    split_data,
+    evaluate,
+)
 
-with open("config/example.yaml") as f:
-    cfg = yaml.safe_load(f)
-
-train, valid, test = train_valid_test_split(df, **cfg["data_split"])
-gru = GRU4Rec(**cfg["model"])
-gru.fit(train)
+config = load_config("config/example.yaml")
+train, valid, test = split_data(df, config)
+gru = build_model(config)
+gru.fit(train, **config["training"], **config["data"])
+recall, mrr = evaluate(gru, test, config)
 ```
 
 The notebook `example.ipynb` demonstrates this workflow end-to-end.

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,10 +1,39 @@
 model:
   layers: [10]
-  n_epochs: 1
+  loss: cross-entropy
   batch_size: 2
+  dropout_p_embed: 0.0
+  dropout_p_hidden: 0.0
   learning_rate: 0.05
+  momentum: 0.0
+  sample_alpha: 0.5
+  n_sample: 2048
+  embedding: 0
+  constrained_embedding: true
+  n_epochs: 1
+  bpreg: 1.0
+  elu_param: 0.5
+  logq: 0.0
   device: cpu
+
+data:
+  session_key: SessionId
+  item_key: ItemId
+  time_key: Time
 
 data_split:
   valid_fraction: 0.1
   test_fraction: 0.1
+
+training:
+  sample_cache_max_size: 10000000
+  compatibility_mode: true
+
+evaluation:
+  cutoff: [20]
+  batch_size: 512
+  mode: conservative
+
+paths:
+  model_save: model.pth
+  model_load: model.pth

--- a/example.ipynb
+++ b/example.ipynb
@@ -14,9 +14,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import yaml\n",
-    "from gru4rec import GRU4Rec, train_valid_test_split\n",
-    "from gru4rec.evaluation import batch_eval\n"
+    "from gru4rec.config import load_config, build_model, split_data, evaluate\n"
    ]
   },
   {
@@ -25,8 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"config/example.yaml\") as f:\n",
-    "    config = yaml.safe_load(f)\n"
+    "config = load_config(\"config/example.yaml\")\n"
    ]
   },
   {
@@ -48,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train, valid, test = train_valid_test_split(data, **config['data_split'])\n"
+    "train, valid, test = split_data(data, config)\n"
    ]
   },
   {
@@ -57,8 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gru = GRU4Rec(**config['model'])\n",
-    "gru.fit(train)\n"
+    "gru = build_model(config)\n",
+    "gru.fit(train, **config['training'], **config['data'])\n"
    ]
   },
   {
@@ -67,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "recall, mrr = batch_eval(gru, test)\n",
+    "recall, mrr = evaluate(gru, test, config)\n",
     "print(recall, mrr)\n"
    ]
   }

--- a/gru4rec/__init__.py
+++ b/gru4rec/__init__.py
@@ -5,6 +5,14 @@ from .model import GRUEmbedding, GRU4RecModel
 from .optimizers import IndexedAdagradM
 from .gru4rec import GRU4Rec
 from .data_loader import train_valid_test_split
+from .config import (
+    load_config,
+    build_model,
+    split_data,
+    evaluate,
+    save_model,
+    load_model,
+)
 
 __all__ = [
     "IndexedAdagradM",
@@ -13,4 +21,10 @@ __all__ = [
     "SessionDataIterator",
     "GRU4Rec",
     "train_valid_test_split",
+    "load_config",
+    "build_model",
+    "split_data",
+    "evaluate",
+    "save_model",
+    "load_model",
 ]

--- a/gru4rec/config.py
+++ b/gru4rec/config.py
@@ -1,0 +1,51 @@
+import yaml
+from .gru4rec import GRU4Rec
+from .data_loader import train_valid_test_split
+from .evaluation import batch_eval
+
+
+def load_config(path: str) -> dict:
+    """Load a YAML configuration file."""
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def build_model(cfg: dict) -> GRU4Rec:
+    """Instantiate :class:`GRU4Rec` from ``cfg``."""
+    model_cfg = cfg.get("model", {})
+    return GRU4Rec(**model_cfg)
+
+
+def split_data(df, cfg: dict):
+    """Split a DataFrame into train/validation/test sets.
+
+    Parameters are taken from both ``cfg['data']`` for column names and
+    ``cfg['data_split']`` for the split fractions.
+    """
+    data_cfg = cfg.get("data", {})
+    split_cfg = cfg.get("data_split", {})
+    return train_valid_test_split(df, **split_cfg, **data_cfg)
+
+
+def evaluate(gru: GRU4Rec, test_df, cfg: dict):
+    """Evaluate ``gru`` on ``test_df`` using ``cfg`` parameters."""
+    eval_cfg = cfg.get("evaluation", {})
+    data_cfg = cfg.get("data", {})
+    return batch_eval(gru, test_df, **eval_cfg, **data_cfg)
+
+
+def save_model(gru: GRU4Rec, cfg: dict) -> None:
+    """Save ``gru`` to the path specified in ``cfg['paths']['model_save']``."""
+    path = cfg.get("paths", {}).get("model_save")
+    if path:
+        gru.savemodel(path)
+
+
+def load_model(cfg: dict) -> GRU4Rec:
+    """Load a model from ``cfg['paths']['model_load']`` if provided."""
+    paths = cfg.get("paths", {})
+    load_path = paths.get("model_load")
+    if not load_path:
+        raise ValueError("No model_load path specified in configuration")
+    device = cfg.get("model", {}).get("device", "cpu")
+    return GRU4Rec.loadmodel(load_path, device=device)


### PR DESCRIPTION
## Summary
- add configuration helpers to create models, split data, evaluate, and save/load
- extend example YAML with training, data, evaluation, and path settings
- update README and example notebook to use expanded configuration

## Testing
- `python -m py_compile gru4rec/config.py gru4rec/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a872071b7c832ba738e08543128db9